### PR TITLE
docs(LICENSE): add lazypool to owners list

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -18,6 +18,7 @@ MIT/X Consortium License
 © 2015-2016 Eric Pruitt <eric.pruitt@gmail.com>
 © 2016-2017 Markus Teich <markus.teich@stusta.mhn.de>
 © 2020-2022 Chris Down <chris@chrisdown.name>
+© 2022-2025 Lazypool <lazypool@proton.me>
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
Add `lazypool` to owners list in MIT LICENSE.